### PR TITLE
Add more architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       arch: arm64
     - os: windows
       arch: arm64
+    - julia: nightly
+      arch: arm64
 notifications:
   email: false
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,22 @@ os:
   - linux
   - osx
   - windows
+arch:
+  - x64
+  - x86
+  - arm64
 julia:
   - 1.0
-  - 1.1
+  - 1.2
   - nightly
+matrix:
+  exclude:
+    - os: osx
+      arch: x86
+    - os: osx
+      arch: arm64
+    - os: windows
+      arch: arm64
 notifications:
   email: false
 after_success:


### PR DESCRIPTION
This shows an example of how to set up Travis CI for testing on Linux, Windows, and macOS on x86, x64, and ARM platforms (where applicable—note the `exclude`).